### PR TITLE
Implement a basic installer using Wix v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,7 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Source binaries
+op_x86.exe
+op_x64.exe

--- a/1PasswordCliInstaller.sln
+++ b/1PasswordCliInstaller.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32802.440
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "1PasswordCliInstaller", "1PasswordCliInstaller\1PasswordCliInstaller.wixproj", "{61209C65-CA3E-427B-8AE2-250F2C4FF914}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{61209C65-CA3E-427B-8AE2-250F2C4FF914}.Debug|x64.ActiveCfg = Debug|x64
+		{61209C65-CA3E-427B-8AE2-250F2C4FF914}.Debug|x64.Build.0 = Debug|x64
+		{61209C65-CA3E-427B-8AE2-250F2C4FF914}.Debug|x86.ActiveCfg = Debug|x86
+		{61209C65-CA3E-427B-8AE2-250F2C4FF914}.Debug|x86.Build.0 = Debug|x86
+		{61209C65-CA3E-427B-8AE2-250F2C4FF914}.Release|x64.ActiveCfg = Release|x64
+		{61209C65-CA3E-427B-8AE2-250F2C4FF914}.Release|x64.Build.0 = Release|x64
+		{61209C65-CA3E-427B-8AE2-250F2C4FF914}.Release|x86.ActiveCfg = Release|x86
+		{61209C65-CA3E-427B-8AE2-250F2C4FF914}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {73AF923E-5320-48AD-BA68-8538863AF05D}
+	EndGlobalSection
+EndGlobal

--- a/1PasswordCliInstaller/1PasswordCliInstaller.wixproj
+++ b/1PasswordCliInstaller/1PasswordCliInstaller.wixproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>3.10</ProductVersion>
+    <ProjectGuid>61209c65-ca3e-427b-8ae2-250f2c4ff914</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputName>1Password CLI</OutputName>
+    <OutputType>Package</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <OutputName>1Password CLI (x86-Debug)</OutputName>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <OutputName>1Password CLI (x86)</OutputName>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <OutputName>1Password CLI (x64-Debug)</OutputName>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <OutputName>1Password CLI (x64)</OutputName>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Product.wxs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Config.wxi" />
+  </ItemGroup>
+  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
+    <Error Text="The WiX Toolset v3.11 build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases/v3.11/stable" />
+  </Target>
+</Project>

--- a/1PasswordCliInstaller/Config.wxi
+++ b/1PasswordCliInstaller/Config.wxi
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Include>
+	<?define Manufacturer = "Nick Charlton" ?>
+	<?define ProductVersion = "2.8.0" ?>
+
+	<?if $(var.Platform) = x64?>
+	<?define PlatformProductName = "1Password CLI (x64)"?>
+	<?define PlatformUpgradeCode = "D7D4A655-76AB-45C9-B50F-0A8C1009E8F5"?>
+	<?define PlatformProgramFilesFolder = "ProgramFiles64Folder"?>
+	<?else ?>
+	<?define PlatformProductName = "1Password CLI (x86)"?>
+	<?define PlatformUpgradeCode = "E21CFAE2-49F0-489C-A069-437374D61DA5"?>
+	<?define PlatformProgramFilesFolder = "ProgramFilesFolder"?>
+	<?endif ?>
+</Include>

--- a/1PasswordCliInstaller/Product.wxs
+++ b/1PasswordCliInstaller/Product.wxs
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?include Config.wxi?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+	<Product Id="*" Name="$(var.PlatformProductName)" Language="1033" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.PlatformUpgradeCode)">
+		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
+
+		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed. Setup will now exit." />
+		<MediaTemplate EmbedCab="yes" />
+
+		<Directory Id="TARGETDIR" Name="SourceDir">
+			<Directory Id="$(var.PlatformProgramFilesFolder)">
+				<Directory Id="INSTALLFOLDER" Name="1Password CLI" />
+			</Directory>
+		</Directory>
+
+		<ComponentGroup Directory="INSTALLFOLDER" Id="ProductComponentGroup">
+			<Component Id="cmp_op.exe" Guid="*">
+				<?if $(var.Platform) = x64 ?>
+				<File KeyPath="yes" Name="op.exe" Source="op_x64.exe" />
+				<?else ?>
+				<File KeyPath="yes" Name="op.exe" Source="op_x86.exe" />
+				<?endif ?>
+			</Component>
+			<Component Id="cmp_EnvironmentVariable" Guid="46D0B3FB-60B3-4F08-A911-CC03F3907DC2" KeyPath="yes">
+				<Environment Id="InstallPath"
+					Name="Path"
+					Value="[INSTALLFOLDER]"
+					Action="set"
+					System="yes"
+					Part="last"
+					Separator=";" />
+			</Component>
+			<Component Id="cmp_RegistryEntry" Guid="*">
+				<RegistryKey Root='HKLM' Key='Software\[Manufacturer]\[ProductName]'>
+					<RegistryValue KeyPath='yes' Type='string' Name='Install location' Value='[INSTALLFOLDER]' />
+				</RegistryKey>
+			</Component>
+		</ComponentGroup>
+
+		<Feature Id="ProductFeature">
+			<ComponentGroupRef Id="ProductComponentGroup" />
+		</Feature>
+	</Product>
+</Wix>


### PR DESCRIPTION
This started off with the template from the VS 2019 extension, then taking a lot of inspiration from `kurtanr`'s `WiXInstallerExamples` project to put it all together.

We can now generate both x86 and x64 installers that put the file in the correct path and set the environment variable correctly for each.

The bundled binaries come directly from 1Password's release page.

https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2019Extension https://github.com/kurtanr/WiXInstallerExamples/tree/main/02_x86_x64_Installer
https://app-updates.agilebits.com/product_history/CLI2